### PR TITLE
fix: 글쓰기 저장 버튼 비활성화 버그 및 첨부 파일 리스트 미출력 버그 수정 작업 완료(Issue #78 해결)

### DIFF
--- a/src/features/write/write.html
+++ b/src/features/write/write.html
@@ -19,7 +19,7 @@
       <!-- 취소 버튼 선택 시 이전 페이지로 이동 -->
       <div class="post-header__cancel-btn">
         <button id="postCancel" aria-label="글쓰기 취소 버튼">
-          <img src="/src/assets/icons/top/top_cancel.svg" alt="글쓰기 취소">
+          <img src="/assets/icons/top/top_cancel.svg" alt="글쓰기 취소">
         </button>
       </div>
       <h1 class="post-header__title">글쓰기</h1>
@@ -27,9 +27,9 @@
         <!-- 저장 버튼 선택 시 게시글 post 로 서버 요청 전송 -->
         <button id="postSave" type="submit" aria-label="글쓰기 저장 버튼">
           <!-- 글쓰기 메인 폼의 모든 입력란이 차지 않은 경우, 글쓰기 저장 비활성화 상태 -->
-          <img src="/src/assets/icons/top/top_check.svg" alt="글쓰기 저장 비활성화" class="disabled" aria-disabled="true">
+          <img src="/assets/icons/top/top_check.svg" alt="글쓰기 저장 비활성화" class="disabled" aria-disabled="true">
           <!-- 글쓰기 메인 폼의 모든 입력이 완료되었을 때 활성화 -->
-          <img src="/src/assets/icons/top/top_check_green.svg" class="active hidden" alt="글쓰기 저장">
+          <img src="/assets/icons/top/top_check_green.svg" class="active hidden" alt="글쓰기 저장">
         </button>
       </div>
     </header>
@@ -62,25 +62,20 @@
         <div class="post-toolbar__upload">
           <label aria-label="파일 업로드" for="uploadFile">
             <input type="file" id="uploadFile" accept=".jpg, .jpeg, .svg, .png" class="ir">
-            <img src="/src/assets/icons/actions/addfile.svg">
+            <img src="/assets/icons/actions/addfile.svg">
           </label>
         </div>
         <div class="post-toolbar__align">
-          <img src="/src/assets/icons/actions/align_l.svg">
+          <img src="/assets/icons/actions/align_l.svg">
         </div>
         <div class="post-toolbar__hide-keyboard">
-          <img src="/src/assets/icons/actions/hide_keyboard.svg">
+          <img src="/assets/icons/actions/hide_keyboard.svg">
         </div>
       </section>
     </footer>
     <div id="navigation"></div>
   </div>
-  <script>
-    fetch('/src/features/components/navigation/navigation.html')
-      .then(response => response.text()).then(data => {
-        document.getElementById('navigation').innerHTML = data;
-      });
-  </script>
+  <script type="module" src="/src/features/components/navigation/navigation.js"></script>
 </body>
 
 </html>

--- a/src/features/write/write.html
+++ b/src/features/write/write.html
@@ -27,9 +27,9 @@
         <!-- 저장 버튼 선택 시 게시글 post 로 서버 요청 전송 -->
         <button id="postSave" type="submit" aria-label="글쓰기 저장 버튼">
           <!-- 글쓰기 메인 폼의 모든 입력란이 차지 않은 경우, 글쓰기 저장 비활성화 상태 -->
-          <img src="/src/assets/icons/top/top_check.svg" alt="글쓰기 저장 비활성화" class="hidden" aria-disabled="true">
+          <img src="/src/assets/icons/top/top_check.svg" alt="글쓰기 저장 비활성화" class="disabled" aria-disabled="true">
           <!-- 글쓰기 메인 폼의 모든 입력이 완료되었을 때 활성화 -->
-          <img src="/src/assets/icons/top/top_check_green.svg" alt="글쓰기 저장">
+          <img src="/src/assets/icons/top/top_check_green.svg" class="active hidden" alt="글쓰기 저장">
         </button>
       </div>
     </header>
@@ -57,6 +57,7 @@
     </main>
     <footer class="post-utils">
       <!-- 파일 업로드 버튼, type="file" 로 브라우저 파일 탐색창 출력 -->
+      <ul class="file-list hidden"></ul>
       <section class="post-toolbar">
         <div class="post-toolbar__upload">
           <label aria-label="파일 업로드" for="uploadFile">

--- a/src/features/write/write.js
+++ b/src/features/write/write.js
@@ -90,7 +90,6 @@ window.addEventListener('load', function () {
 
     // 업로드된 파일 객체를 배열로 변경
     const selectedFiles = Array.from($uploadFile.files);
-    console.log(selectedFiles)
     const imageFormData = new FormData();
 
     // 업로드된 파일을 FormData 에 추가
@@ -118,7 +117,6 @@ window.addEventListener('load', function () {
         })
           // 요청 성공 시 실행 코드
           .then(response => {
-            console.log(response.data);
             const imgPath = [];
             // 파일 데이터에서 이미지 url만 배열에 저장
             for (let i = 0; i < response.data.item.length; i++) {


### PR DESCRIPTION
## PR 유형

- [] 새로운 기능 추가
- [o] 버그 수정
- [] CSS 등 사용자 UI 디자인 변경
- [] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [] 코드 리팩토링
- [] 주석 추가 및 수정
- [] 문서 수정
- [] 테스트 추가, 테스트 리팩토링
- [] 빌드 부분 혹은 패키지 매니저 수정
- [] 파일 혹은 폴더명 수정
- [] 파일 혹은 폴더 삭제

## PR 체크리스트

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [o] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [o] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### PR 상세
깃 충돌을 해결하는 과정에서 일부 추가한 html 태그가 수정되어 버그가 발생했습니다. 버그는 박멸했습니다.

수정 내용
1. 글쓰기 저장 버튼 활성화 버그 
- html 의 글쓰기 저장 버튼 내부 이미지 태그에 클래스가 깃 충돌 해결과정에서 삭제되었습니다.
- class="active", class="disabled"를 추가하여 해당 버그 박멸했습니다.
 
2. 첨부된 이미지 파일 리스트 미출력 오류
- 첨부 파일 리스트에 해당하는 태그가 깃 충돌 해결과정에서 삭제되었습니다.
- 푸터 영역 내부에 <ul class="file-list hidden"> 태그를 추가하여 오류 수정했습니다.

번외:
write.html 파일 내부의 이미지 경로도 수정하였습니다.
깃헙 충돌 해결 과정에서 이전 버전의 이미지 경로로 변경된 것으로 보입니다.

## 이슈

<!-- 이슈 키워드와 함께 #을 입력한 후 이슈 번호를 선택해주세요. -->
<!-- 에시 : resolves #1 -->

resolves #
